### PR TITLE
Fix entry scripts and verify feature coverage

### DIFF
--- a/Run-Me-First.ps1
+++ b/Run-Me-First.ps1
@@ -1,20 +1,21 @@
-﻿\
-    # Run-Me-First.ps1 — Unblock, set policy for session, and launch KOALA-UDP
-    [CmdletBinding()]
-    param()
+﻿# Run-Me-First.ps1 — Unblock, set policy for session, and launch KOALA-UDP
+[CmdletBinding()]
+param()
 
-    try {
-        Write-Host "Unblocking files..." -ForegroundColor Cyan
-        Get-ChildItem -Recurse -File $PSScriptRoot | Unblock-File -ErrorAction SilentlyContinue
-    } catch { }
+try {
+    Write-Host "Unblocking files..." -ForegroundColor Cyan
+    Get-ChildItem -Recurse -File $PSScriptRoot | Unblock-File -ErrorAction SilentlyContinue
+} catch {
+    # Non-fatal; continue even if Unblock-File is unavailable
+}
 
-    Write-Host "Setting ExecutionPolicy = Bypass for this session..." -ForegroundColor Cyan
-    Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+Write-Host "Setting ExecutionPolicy = Bypass for this session..." -ForegroundColor Cyan
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
 
-    $main = Join-Path $PSScriptRoot "main.ps1"
-    if (Test-Path $main) {
-        Write-Host "Launching main.ps1 ..." -ForegroundColor Green
-        & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $main
-    } else {
-        Write-Host "main.ps1 not found next to this script." -ForegroundColor Red
-    }
+$main = Join-Path $PSScriptRoot "main.ps1"
+if (Test-Path $main) {
+    Write-Host "Launching main.ps1 ..." -ForegroundColor Green
+    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $main
+} else {
+    Write-Host "main.ps1 not found next to this script." -ForegroundColor Red
+}

--- a/main.ps1
+++ b/main.ps1
@@ -1,20 +1,19 @@
-﻿\
-    # main.ps1 — Auto-generated split from V3-testing.ps1 (adjusted mapping)
-    Set-StrictMode -Version Latest
-    $ErrorActionPreference = 'Stop'
+﻿# main.ps1 — Auto-generated split from V3-testing.ps1 (adjusted mapping)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
 
-    . "$PSScriptRoot\helpers.ps1"
-    . "$PSScriptRoot\networkTweaks.ps1"
-    . "$PSScriptRoot\systemTweaks.ps1"
-    . "$PSScriptRoot\serviceTweaks.ps1"
-    . "$PSScriptRoot\gamesTweaks.ps1"
-    . "$PSScriptRoot\backup.ps1"
-    . "$PSScriptRoot\benchmark.ps1"
-    . "$PSScriptRoot\orchestrator.ps1"
-    . "$PSScriptRoot\gui.ps1"
+. "$PSScriptRoot\helpers.ps1"
+. "$PSScriptRoot\networkTweaks.ps1"
+. "$PSScriptRoot\systemTweaks.ps1"
+. "$PSScriptRoot\serviceTweaks.ps1"
+. "$PSScriptRoot\gamesTweaks.ps1"
+. "$PSScriptRoot\backup.ps1"
+. "$PSScriptRoot\benchmark.ps1"
+. "$PSScriptRoot\orchestrator.ps1"
+. "$PSScriptRoot\gui.ps1"
 
-    try {
-        Initialize-Application
-    } catch {
-        Write-Host "Initialize-Application failed: $($_.Exception.Message)" -ForegroundColor Red
-    }
+try {
+    Initialize-Application
+} catch {
+    Write-Host "Initialize-Application failed: $($_.Exception.Message)" -ForegroundColor Red
+}


### PR DESCRIPTION
## Summary
- remove stray backslash and indentation from the PowerShell entry scripts so they execute cleanly
- keep the entrypoint logic intact while documenting the non-fatal unblock failure handling
- verify the split scripts expose the same set of functions as the upstream V3-testing.ps1 monolith

## Testing
- N/A (PowerShell is not available in this Linux container)


------
https://chatgpt.com/codex/tasks/task_e_68e395a885b48320a9f0bbcfb6eeedad